### PR TITLE
Remove PHP4 support to resolve PHP Strict warning

### DIFF
--- a/members.php
+++ b/members.php
@@ -33,17 +33,7 @@
 class Members_Load {
 
 	/**
-	 * PHP4 constructor method.  This will be removed once the plugin only supports WordPress 3.2, 
-	 * which is the version that drops PHP4 support.
-	 *
-	 * @since 0.2.0
-	 */
-	function Members_Load() {
-		$this->__construct();
-	}
-
-	/**
-	 * PHP5 constructor method.
+	 * Constructor method.
 	 *
 	 * @since 0.2.0
 	 */


### PR DESCRIPTION
On the plugin page it states "Requires: 3.4 or higher" and that requires PHP 5.2.4 or greater...
... we can resolve the PHP Strict error which is caused by PHP4 specific code.
