### PR TITLE
Allow renaming of the plugin directory

### DIFF
--- a/members.php
+++ b/members.php
@@ -131,7 +131,7 @@ class Members_Load {
 	function i18n() {
 
 		/* Load the translation of the plugin. */
-		load_plugin_textdomain( 'members', false, 'members/languages' );
+		load_plugin_textdomain( 'members', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 	}
 
 	/**


### PR DESCRIPTION
As per WordPress guidelines
https://codex.wordpress.org/Function_Reference/load_plugin_textdomain