### PR TITLE
JavaScript tweaks

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,25 +1,21 @@
-$j = jQuery.noConflict();
+(function($){
 
-$j(document).ready(
-	function() {
+	$(document).ready( function() {
 
-		$j( '.hide-if-no-js' ).show();
+		$( '.hide-if-no-js' ).show();
 
-		$j( '#members-add-new-cap' ).click(
-			function() {
-				$j( 'p.new-cap-holder' ).append( '<input type="text" class="new-cap" name="new-cap[]" value="" size="20" />' );
+		$( '#members-add-new-cap' ).click( function() {
+			$( 'p.new-cap-holder' ).append( '<input type="text" class="new-cap" name="new-cap[]" value="" size="20" />' );
+		});
+
+		$( 'div.members-role-checkbox input[type="checkbox"]' ).click( function() {
+			if ( $( this ).prop( 'checked' ) ) {
+				$( this ).next( 'label' ).addClass( 'has-cap' );
+			} else {
+				$( this ).next( 'label' ).removeClass( 'has-cap' );
 			}
-		);
+		});
 
-		$j( 'div.members-role-checkbox input[type="checkbox"]' ).click(
-			function() {
-				if ( $j( this ).is( ':checked' ) ) {
-					$j( this ).next( 'label' ).addClass( 'has-cap' );
-				}
-				else {
-					$j( this ).next( 'label' ).removeClass( 'has-cap' );
-				}
-			}
-		);
-	}
-);
+	});
+
+})(jQuery);


### PR DESCRIPTION
Change noConflict for closure to meet guideline at https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#globals and avoid creating a global.
Use recommended `prop( 'checked' )` to verify checked property instead of `is( ':checked' )`