### PR TITLE
Admin janitorial work

### DIFF
--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -21,7 +21,7 @@ final class Members_Settings_Page {
 	public $settings_page = '';
 
 	/**
-	 * Holds an array the plugin settings.
+	 * Holds an array of plugin settings.
 	 *
 	 * @since  1.0.0
 	 * @access public

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -86,7 +86,7 @@ final class Members_Settings_Page {
 		register_setting( 'members_settings', 'members_settings', array( $this, 'validate_settings' ) );
 
 		// Add settings sections.
-		add_settings_section( 'roles_caps',          esc_html__( 'Role and Capabilities', 'members' ), array( $this, 'section_roles_caps'          ), $this->settings_page );
+		add_settings_section( 'roles_caps',          esc_html__( 'Roles and Capabilities', 'members' ), array( $this, 'section_roles_caps'          ), $this->settings_page );
 		add_settings_section( 'content_permissions', esc_html__( 'Content Permissions',   'members' ), array( $this, 'section_content_permissions' ), $this->settings_page );
 		add_settings_section( 'sidebar_widgets',     esc_html__( 'Sidebar Widgets',       'members' ), array( $this, 'section_sidebar_widgets'     ), $this->settings_page );
 		add_settings_section( 'private_site',        esc_html__( 'Private Site',          'members' ), array( $this, 'section_private_site'        ), $this->settings_page );

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -96,7 +96,7 @@ final class Members_Settings_Page {
 		add_settings_field( 'enable_cap_manager',  esc_html__( 'Capability Manager', 'members' ), array( $this, 'field_enable_cap_manager'  ), $this->settings_page, 'roles_caps' );
 
 		add_settings_field( 'enable_content_permissions', esc_html__( 'Enable Permissions', 'members' ), array( $this, 'field_enable_content_permissions' ), $this->settings_page, 'content_permissions' );
-		add_settings_field( 'content_permissions_error',  esc_html__( 'Error Message',              'members' ), array( $this, 'field_content_permissions_error'  ), $this->settings_page, 'content_permissions' );
+		add_settings_field( 'content_permissions_error',  esc_html__( 'Error Message',      'members' ), array( $this, 'field_content_permissions_error'  ), $this->settings_page, 'content_permissions' );
 
 		add_settings_field( 'widget_login', esc_html__( 'Login Widget', 'members' ), array( $this, 'field_widget_login' ), $this->settings_page, 'sidebar_widgets' );
 		add_settings_field( 'widget_users', esc_html__( 'Users Widget', 'members' ), array( $this, 'field_widget_users' ), $this->settings_page, 'sidebar_widgets' );

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -87,9 +87,9 @@ final class Members_Settings_Page {
 
 		// Add settings sections.
 		add_settings_section( 'roles_caps',          esc_html__( 'Roles and Capabilities', 'members' ), array( $this, 'section_roles_caps'          ), $this->settings_page );
-		add_settings_section( 'content_permissions', esc_html__( 'Content Permissions',   'members' ), array( $this, 'section_content_permissions' ), $this->settings_page );
-		add_settings_section( 'sidebar_widgets',     esc_html__( 'Sidebar Widgets',       'members' ), array( $this, 'section_sidebar_widgets'     ), $this->settings_page );
-		add_settings_section( 'private_site',        esc_html__( 'Private Site',          'members' ), array( $this, 'section_private_site'        ), $this->settings_page );
+		add_settings_section( 'content_permissions', esc_html__( 'Content Permissions',    'members' ), array( $this, 'section_content_permissions' ), $this->settings_page );
+		add_settings_section( 'sidebar_widgets',     esc_html__( 'Sidebar Widgets',        'members' ), array( $this, 'section_sidebar_widgets'     ), $this->settings_page );
+		add_settings_section( 'private_site',        esc_html__( 'Private Site',           'members' ), array( $this, 'section_private_site'        ), $this->settings_page );
 
 		// Add settings fields.
 		add_settings_field( 'enable_role_manager', esc_html__( 'Role Manager',       'members' ), array( $this, 'field_enable_role_manager' ), $this->settings_page, 'roles_caps' );


### PR DESCRIPTION
Just a few typos  and alignment issues I noticed while going through the admin class settings file.

I wasn't sure whether you preferred 
`Holds an array of plugin settings.` or 
`Holds an array of the plugin settings.`, but I went with the former.

Thanks for your continued development and maintenance of this plugin, it's been a great help!