### PR TITLE
ADDED actions at the top and bottom of the content permissions metabox.

### DIFF
--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -119,7 +119,17 @@ final class Members_Meta_Box_Content_Permissions {
 		if ( empty( $roles ) )
 			$roles = members_convert_old_post_meta( $post->ID );
 
-		wp_nonce_field( 'members_cp_meta_nonce', 'members_cp_meta' ); ?>
+		wp_nonce_field( 'members_cp_meta_nonce', 'members_cp_meta' );
+
+		/**
+		 * Fires at the top of the content permissions metabox.
+		 *
+		 * @since 1.0.3
+		 *
+		 * @param WP_Post Object  $post The current WordPress post object.
+		 */
+		do_action( 'members_content_permissions_metabox_top', $post );
+		?>
 
 		<p>
 			<?php esc_html_e( "Limit access to this post's content to users of the selected roles.", 'members' ); ?>
@@ -150,7 +160,16 @@ final class Members_Meta_Box_Content_Permissions {
 			<textarea class="widefat" id="members_access_error" name="members_access_error" rows="6"><?php echo esc_textarea( get_post_meta( $post->ID, '_members_access_error', true ) ); ?></textarea>
 			<span class="howto"><?php _e( 'Message shown to users that do no have permission to view the post.', 'members' ); ?></span>
 		</p>
-	<?php }
+	<?php
+		/**
+		 * Fires at the bottom of the content permissions metabox.
+		 *
+		 * @since 1.0.3
+		 *
+		 * @param WP_Post Object  $post The current WordPress post object.
+		 */
+		do_action( 'members_content_permissions_metabox_bottom', $post );
+	}
 
 	/**
 	 * Saves the post meta.


### PR DESCRIPTION
This will allow us to hook in and modify what is shown before the roles list and docs.

Contains WordPress standards compliant hook documentation.

Potential use-case: combining the members plugin with JJJ's User Groups plugin (meaning that we'd be able to limit content to a specific user group, rather than by a role)

(As an aside the commit message for this is pretty funny. Autocorrect changed 'metabox' for 'meatball'. Nice.)