### PR TITLE
Added hooks before and after the content permissions metabox. 

### DIFF
--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -119,7 +119,17 @@ final class Members_Meta_Box_Content_Permissions {
 		if ( empty( $roles ) )
 			$roles = members_convert_old_post_meta( $post->ID );
 
-		wp_nonce_field( 'members_cp_meta_nonce', 'members_cp_meta' ); ?>
+		wp_nonce_field( 'members_cp_meta_nonce', 'members_cp_meta' );
+
+		/**
+		 * Fires at the top of the content permissions metabox.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param WP_Post Object  $post The current WordPress post object.
+		 */
+		do_action( 'members_cp_metabox_before', $post );
+		?>
 
 		<p>
 			<?php esc_html_e( "Limit access to this post's content to users of the selected roles.", 'members' ); ?>
@@ -150,7 +160,16 @@ final class Members_Meta_Box_Content_Permissions {
 			<textarea class="widefat" id="members_access_error" name="members_access_error" rows="6"><?php echo esc_textarea( get_post_meta( $post->ID, '_members_access_error', true ) ); ?></textarea>
 			<span class="howto"><?php _e( 'Message shown to users that do no have permission to view the post.', 'members' ); ?></span>
 		</p>
-	<?php }
+	<?php
+		/**
+		 * Fires at the bottom of the content permissions metabox.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param WP_Post Object  $post The current WordPress post object.
+		 */
+		do_action( 'members_cp_metabox_after', $post );
+	}
 
 	/**
 	 * Saves the post meta.

--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -122,13 +122,13 @@ final class Members_Meta_Box_Content_Permissions {
 		wp_nonce_field( 'members_cp_meta_nonce', 'members_cp_meta' );
 
 		/**
-		 * Fires at the top of the content permissions metabox.
+		 * Fires at the top of the content permissions meta box.
 		 *
 		 * @since 1.1.0
 		 *
 		 * @param WP_Post Object  $post The current WordPress post object.
 		 */
-		do_action( 'members_cp_metabox_before', $post );
+		do_action( 'members_cp_meta_box_before', $post );
 		?>
 
 		<p>
@@ -162,13 +162,13 @@ final class Members_Meta_Box_Content_Permissions {
 		</p>
 	<?php
 		/**
-		 * Fires at the bottom of the content permissions metabox.
+		 * Fires at the bottom of the content permissions meta box.
 		 *
 		 * @since 1.1.0
 		 *
 		 * @param WP_Post Object  $post The current WordPress post object.
 		 */
-		do_action( 'members_cp_metabox_after', $post );
+		do_action( 'members_cp_meta_box_after', $post );
 	}
 
 	/**


### PR DESCRIPTION
Includes WP Documentation standards compliant hook docs. Ref: https://github.com/justintadlock/members/issues/59