### PR TITLE
Early sanitization, late escaping

### DIFF
--- a/admin/class-cap-tabs.php
+++ b/admin/class-cap-tabs.php
@@ -201,7 +201,7 @@ final class Members_Cap_Tabs {
 			<?php $icon = preg_match( '/dashicons-/', $section->icon ) ? sprintf( 'dashicons %s', sanitize_html_class( $section->icon ) ) : esc_attr( $section->icon ); ?>
 
 			<li class="members-tab-title">
-				<a href="<?php echo esc_attr( "#members-tab-{$section->section}" ); ?>"><i class="<?php echo $icon; ?>"></i> <span class="label"><?php echo esc_html( $section->label ); ?></span></a>
+				<a href="<?php echo esc_attr( "#members-tab-{$section->section}" ); ?>"><i class="<?php echo esc_attr( $icon ); ?>"></i> <span class="label"><?php echo esc_html( $section->label ); ?></span></a>
 			</li>
 
 		<?php endforeach; ?>

--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -188,7 +188,7 @@ final class Members_Meta_Box_Content_Permissions {
 		$current_roles = members_get_post_roles( $post_id );
 
 		// Get the new roles.
-		$new_roles = isset( $_POST['members_access_role'] ) ? array_map( 'members_sanitize_role', $_POST['members_access_role'] ) : '';
+		$new_roles = isset( $_POST['members_access_role'] ) ? array_map( 'members_sanitize_role', wp_unslash( $_POST['members_access_role'] ) ) : '';
 
 		// If we have an array of new roles, set the roles.
 		if ( is_array( $new_roles ) )
@@ -204,7 +204,7 @@ final class Members_Meta_Box_Content_Permissions {
 		$old_message = members_get_post_access_message( $post_id );
 
 		// Get the new message.
-		$new_message = isset( $_POST['members_access_error'] ) ? stripslashes( wp_filter_post_kses( addslashes( $_POST['members_access_error'] ) ) ) : '';
+		$new_message = isset( $_POST['members_access_error'] ) ? stripslashes( wp_filter_post_kses( addslashes( wp_unslash( $_POST['members_access_error'] ) ) ) ) : '';
 
 		// If we have don't have a new message but do have an old one, delete it.
 		if ( '' == $new_message && $old_message )

--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -204,7 +204,7 @@ final class Members_Meta_Box_Content_Permissions {
 		$old_message = members_get_post_access_message( $post_id );
 
 		// Get the new message.
-		$new_message = isset( $_POST['members_access_error'] ) ? stripslashes( wp_filter_post_kses( addslashes( wp_unslash( $_POST['members_access_error'] ) ) ) ) : '';
+		$new_message = isset( $_POST['members_access_error'] ) ? wp_kses_post( wp_unslash( $_POST['members_access_error'] ) ) : '';
 
 		// If we have don't have a new message but do have an old one, delete it.
 		if ( '' == $new_message && $old_message )

--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -155,7 +155,7 @@ final class Members_Meta_Box_Content_Permissions {
 		<p>
 			<label for="members_access_error"><?php esc_html_e( 'Custom error message:', 'members' ); ?></label>
 			<textarea class="widefat" id="members_access_error" name="members_access_error" rows="6"><?php echo esc_textarea( get_post_meta( $post->ID, '_members_access_error', true ) ); ?></textarea>
-			<span class="howto"><?php _e( 'Message shown to users that do not have permission to view the post.', 'members' ); ?></span>
+			<span class="howto"><?php esc_html_e( 'Message shown to users that do not have permission to view the post.', 'members' ); ?></span>
 		</p><?php
 
 		// Hook that fires at the end of the meta box.
@@ -188,7 +188,7 @@ final class Members_Meta_Box_Content_Permissions {
 		$current_roles = members_get_post_roles( $post_id );
 
 		// Get the new roles.
-		$new_roles = isset( $_POST['members_access_role'] ) ? $_POST['members_access_role'] : '';
+		$new_roles = isset( $_POST['members_access_role'] ) ? array_map( 'members_sanitize_role', $_POST['members_access_role'] ) : '';
 
 		// If we have an array of new roles, set the roles.
 		if ( is_array( $new_roles ) )

--- a/admin/class-role-edit.php
+++ b/admin/class-role-edit.php
@@ -118,15 +118,15 @@ final class Members_Admin_Role_Edit {
 			check_admin_referer( 'edit_role', 'members_edit_role_nonce' );
 
 			// Get the granted and denied caps.
-			$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_map( 'members_sanitize_role', $_POST['grant-caps'] ) : array();
-			$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_map( 'members_sanitize_role', $_POST['deny-caps']  ) : array();
+			$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_map( 'members_sanitize_role', wp_unslash( $_POST['grant-caps'] ) ) : array();
+			$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_map( 'members_sanitize_role', wp_unslash( $_POST['deny-caps']  ) ) : array();
 
 			$grant_caps = array_unique( $grant_caps );
 			$deny_caps  = array_unique( $deny_caps );
 
 			// Get the new (custom) granted and denied caps.
-			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_map( 'members_sanitize_role', $_POST['grant-new-caps'] ) : array();
-			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_map( 'members_sanitize_role', $_POST['deny-new-caps']  ) : array();
+			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_map( 'members_sanitize_role', wp_unslash( $_POST['grant-new-caps'] ) ) : array();
+			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_map( 'members_sanitize_role', wp_unslash( $_POST['deny-new-caps']  ) ) : array();
 
 			$grant_new_caps = array_unique( $grant_new_caps );
 			$deny_new_caps  = array_unique( $deny_new_caps );

--- a/admin/class-role-edit.php
+++ b/admin/class-role-edit.php
@@ -118,12 +118,18 @@ final class Members_Admin_Role_Edit {
 			check_admin_referer( 'edit_role', 'members_edit_role_nonce' );
 
 			// Get the granted and denied caps.
-			$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_unique( $_POST['grant-caps'] ) : array();
-			$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_unique( $_POST['deny-caps']  ) : array();
+			$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_map( 'members_sanitize_role', $_POST['grant-caps'] ) : array();
+			$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_map( 'members_sanitize_role', $_POST['deny-caps']  ) : array();
+
+			$grant_caps = array_unique( $grant_caps );
+			$deny_caps  = array_unique( $deny_caps );
 
 			// Get the new (custom) granted and denied caps.
-			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_unique( $_POST['grant-new-caps'] ) : array();
-			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_unique( $_POST['deny-new-caps']  ) : array();
+			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_map( 'members_sanitize_role', $_POST['grant-new-caps'] ) : array();
+			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_map( 'members_sanitize_role', $_POST['deny-new-caps']  ) : array();
+
+			$grant_new_caps = array_unique( $grant_new_caps );
+			$deny_new_caps  = array_unique( $deny_new_caps );
 
 			// Get the all and custom cap group objects.
 			$all_group    = members_get_cap_group( 'all'    );
@@ -213,15 +219,15 @@ final class Members_Admin_Role_Edit {
 
 		// If successful update.
 		if ( $this->role_updated )
-			add_settings_error( 'members_edit_role', 'role_updated', sprintf( esc_html__( '%s role updated.', 'members' ), members_get_role_name( $this->role->name ) ), 'updated' );
+			add_settings_error( 'members_edit_role', 'role_updated', sprintf( esc_html__( '%s role updated.', 'members' ), esc_html( members_get_role_name( $this->role->name ) ) ), 'updated' );
 
 		// If the role is not editable.
 		if ( ! $this->is_editable )
-			add_settings_error( 'members_edit_role', 'role_uneditable', sprintf( esc_html__( 'The %s role is not editable. This means that it is most likely added via another plugin for a special use or that you do not have permission to edit it.', 'members' ), members_get_role_name( $this->role->name ) ) );
+			add_settings_error( 'members_edit_role', 'role_uneditable', sprintf( esc_html__( 'The %s role is not editable. This means that it is most likely added via another plugin for a special use or that you do not have permission to edit it.', 'members' ), esc_html( members_get_role_name( $this->role->name ) ) ) );
 
 		// If a new role was added (redirect from new role screen).
 		if ( isset( $_GET['message'] ) && 'role_added' === $_GET['message'] )
-			add_settings_error( 'members_edit_role', 'role_added', sprintf( esc_html__( 'The %s role has been created.', 'members' ), members_get_role_name( $this->role->name ) ), 'updated' );
+			add_settings_error( 'members_edit_role', 'role_added', sprintf( esc_html__( 'The %s role has been created.', 'members' ), esc_html( members_get_role_name( $this->role->name ) ) ), 'updated' );
 
 		// Load page hook.
 		do_action( 'members_load_role_edit' );

--- a/admin/class-role-list-table.php
+++ b/admin/class-role-list-table.php
@@ -245,7 +245,7 @@ class Members_Role_List_Table extends WP_List_Table {
 		}
 
 		// Add the title and role states.
-		$title = sprintf( '<strong><a class="row-title" href="%s">%s</a>%s</strong>', esc_url( members_get_edit_role_url( $role ) ), esc_html( members_get_role_name( $role ) ), $role_states );
+		$title = sprintf( '<strong><a class="row-title" href="%s">%s</a>%s</strong>', esc_url( members_get_edit_role_url( $role ) ), esc_html( members_get_role_name( $role ) ), wp_kses_post( $role_states ) );
 
 		return apply_filters( 'members_manage_roles_column_role_name', $title, $role );
 	}
@@ -397,13 +397,13 @@ class Members_Role_List_Table extends WP_List_Table {
 			$inactive->roles = members_get_inactive_role_slugs();
 
 		$views     = array();
-		$current   = ' class="current"';
+		$current   = 'current';
 		$all_count = count( members_get_role_slugs() );
 
 		// Add the default/all view.
 		$views['all'] = sprintf(
-			'<a%s href="%s">%s</a>',
-			'all' === $this->role_view ? $current : '',
+			'<a class="%s" href="%s">%s</a>',
+			esc_attr( 'all' === $this->role_view ? $current : '' ),
 			esc_url( members_get_edit_roles_url() ),
 			sprintf( _n( 'All %s', 'All %s', $all_count, 'members' ), sprintf( '<span class="count">(%s)</span>', number_format_i18n( $all_count ) ) )
 		);
@@ -425,8 +425,8 @@ class Members_Role_List_Table extends WP_List_Table {
 
 			// Add the view link.
 			$views[ $group->name ] = sprintf(
-				'<a%s href="%s">%s</a>',
-				$group->name === $this->role_view ? $current : '',
+				'<a class="%s" href="%s">%s</a>',
+				esc_attr( $group->name === $this->role_view ? $current : '' ),
 				'all' === $group->name ? esc_url( members_get_edit_roles_url() ) : esc_url( members_get_role_view_url( $group->name ) ),
 				sprintf( translate_nooped_plural( $noop, $count, $noop['domain'] ), sprintf( '<span class="count">(%s)</span>', number_format_i18n( $count ) ) )
 			);

--- a/admin/class-role-new.php
+++ b/admin/class-role-new.php
@@ -124,7 +124,7 @@ final class Members_Admin_Role_New {
 	public function load() {
 
 		// Are we cloning a role?
-		$this->is_clone = isset( $_GET['clone'] ) && members_role_exists( members_sanitize_role( $_GET['clone'] ) );
+		$this->is_clone = isset( $_GET['clone'] ) && members_role_exists( members_sanitize_role( wp_unslash( $_GET['clone'] ) ) );
 
 		if ( $this->is_clone ) {
 
@@ -132,7 +132,7 @@ final class Members_Admin_Role_New {
 			add_filter( 'members_new_role_default_caps', array( $this, 'clone_default_caps' ), 15 );
 
 			// Set the clone role.
-			$this->clone_role = members_sanitize_role( $_GET['clone'] );
+			$this->clone_role = members_sanitize_role( wp_unslash( $_GET['clone'] ) );
 		}
 
 		// Check if the current user can create roles and the form has been submitted.

--- a/admin/class-role-new.php
+++ b/admin/class-role-new.php
@@ -124,7 +124,7 @@ final class Members_Admin_Role_New {
 	public function load() {
 
 		// Are we cloning a role?
-		$this->is_clone = isset( $_GET['clone'] ) && members_role_exists( $_GET['clone'] );
+		$this->is_clone = isset( $_GET['clone'] ) && members_role_exists( members_sanitize_role( $_GET['clone'] ) );
 
 		if ( $this->is_clone ) {
 
@@ -159,8 +159,11 @@ final class Members_Admin_Role_New {
 			// Check if any capabilities were selected.
 			if ( isset( $_POST['grant-caps'] ) || isset( $_POST['deny-caps'] ) ) {
 
-				$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_unique( $_POST['grant-caps'] ) : array();
-				$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_unique( $_POST['deny-caps']  ) : array();
+				$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_map( 'members_sanitize_cap', $_POST['grant-caps'] ) : array();
+				$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_map( 'members_sanitize_cap', $_POST['deny-caps']  ) : array();
+
+				$grant_caps = array_unique( $grant_caps );
+				$deny_caps  = array_unique( $deny_caps );
 
 				foreach ( $_m_caps as $cap ) {
 
@@ -172,8 +175,11 @@ final class Members_Admin_Role_New {
 				}
 			}
 
-			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_unique( $_POST['grant-new-caps'] ) : array();
-			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_unique( $_POST['deny-new-caps']  ) : array();
+			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_map( 'members_sanitize_cap', $_POST['grant-new-caps'] ) : array();
+			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_map( 'members_sanitize_cap', $_POST['deny-new-caps']  ) : array();
+
+			$grant_new_caps = array_unique( $grant_new_caps );
+			$deny_new_caps  = array_unique( $deny_new_caps );
 
 			foreach ( $grant_new_caps as $grant_new_cap ) {
 
@@ -221,7 +227,7 @@ final class Members_Admin_Role_New {
 				}
 
 				// Add role added message.
-				add_settings_error( 'members_role_new', 'role_added', sprintf( esc_html__( 'The %s role has been created.', 'members' ), $this->role_name ), 'updated' );
+				add_settings_error( 'members_role_new', 'role_added', sprintf( esc_html__( 'The %s role has been created.', 'members' ), esc_html( $this->role_name ) ), 'updated' );
 			}
 
 			// If there are new caps, let's assign them.
@@ -234,7 +240,7 @@ final class Members_Admin_Role_New {
 
 			// Add error if this is a duplicate role.
 			if ( $is_duplicate )
-				add_settings_error( 'members_role_new', 'duplicate_role', sprintf( esc_html__( 'The %s role already exists.', 'members' ), $this->role ) );
+				add_settings_error( 'members_role_new', 'duplicate_role', sprintf( esc_html__( 'The %s role already exists.', 'members' ), esc_html( $this->role ) ) );
 
 			// Add error if there's no role name.
 			if ( ! $this->role_name )

--- a/admin/class-role-new.php
+++ b/admin/class-role-new.php
@@ -159,8 +159,8 @@ final class Members_Admin_Role_New {
 			// Check if any capabilities were selected.
 			if ( isset( $_POST['grant-caps'] ) || isset( $_POST['deny-caps'] ) ) {
 
-				$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_map( 'members_sanitize_cap', $_POST['grant-caps'] ) : array();
-				$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_map( 'members_sanitize_cap', $_POST['deny-caps']  ) : array();
+				$grant_caps = ! empty( $_POST['grant-caps'] ) ? array_map( 'members_sanitize_cap', wp_unslash( $_POST['grant-caps'] ) ) : array();
+				$deny_caps  = ! empty( $_POST['deny-caps'] )  ? array_map( 'members_sanitize_cap', wp_unslash( $_POST['deny-caps']  ) ) : array();
 
 				$grant_caps = array_unique( $grant_caps );
 				$deny_caps  = array_unique( $deny_caps );
@@ -175,8 +175,8 @@ final class Members_Admin_Role_New {
 				}
 			}
 
-			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_map( 'members_sanitize_cap', $_POST['grant-new-caps'] ) : array();
-			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_map( 'members_sanitize_cap', $_POST['deny-new-caps']  ) : array();
+			$grant_new_caps = ! empty( $_POST['grant-new-caps'] ) ? array_map( 'members_sanitize_cap', wp_unslash( $_POST['grant-new-caps'] ) ) : array();
+			$deny_new_caps  = ! empty( $_POST['deny-new-caps'] )  ? array_map( 'members_sanitize_cap', wp_unslash( $_POST['deny-new-caps']  ) ) : array();
 
 			$grant_new_caps = array_unique( $grant_new_caps );
 			$deny_new_caps  = array_unique( $deny_new_caps );
@@ -199,11 +199,11 @@ final class Members_Admin_Role_New {
 
 			// Sanitize the new role name/label. We just want to strip any tags here.
 			if ( ! empty( $_POST['role_name'] ) )
-				$this->role_name = wp_strip_all_tags( $_POST['role_name'] );
+				$this->role_name = wp_strip_all_tags( wp_unslash( $_POST['role_name'] ) );
 
 			// Sanitize the new role, removing any unwanted characters.
 			if ( ! empty( $_POST['role'] ) )
-				$this->role = members_sanitize_role( $_POST['role'] );
+				$this->role = members_sanitize_role( wp_unslash( $_POST['role'] ) );
 
 			else if ( $this->role_name )
 				$this->role = members_sanitize_role( $this->role_name );

--- a/admin/class-roles.php
+++ b/admin/class-roles.php
@@ -290,9 +290,9 @@ final class Members_Admin_Roles {
 
 		<ul>
 			<li><?php echo wp_kses_post( __( '<strong>Edit</strong> takes you to the editing screen for that role. You can also reach that screen by clicking on the role name.', 'members' ) ); ?></li>
-			<li><?php  echo wp_kses_post( __( '<strong>Delete</strong> removes your role from this list and permanently deletes it.', 'members' ) ); ?></li>
-			<li><?php  echo wp_kses_post( __( '<strong>Clone</strong> copies the role and takes you to the new role screen to further edit it.', 'members' ) ); ?></li>
-			<li><?php  echo wp_kses_post( __( '<strong>Users</strong> takes you to the users screen and lists the users that have that role.', 'members' ) ); ?></li>
+			<li><?php echo wp_kses_post( __( '<strong>Delete</strong> removes your role from this list and permanently deletes it.', 'members' ) ); ?></li>
+			<li><?php echo wp_kses_post( __( '<strong>Clone</strong> copies the role and takes you to the new role screen to further edit it.', 'members' ) ); ?></li>
+			<li><?php echo wp_kses_post( __( '<strong>Users</strong> takes you to the users screen and lists the users that have that role.', 'members' ) ); ?></li>
 		</ul>
 	<?php }
 

--- a/admin/class-roles.php
+++ b/admin/class-roles.php
@@ -121,7 +121,7 @@ final class Members_Admin_Roles {
 				check_admin_referer( 'delete_role', 'members_delete_role_nonce' );
 
 				// Get the role we want to delete.
-				$role = members_sanitize_role( $_GET['role'] );
+				$role = members_sanitize_role( wp_unslash( $_GET['role'] ) );
 
 				// Check that we have a role before attempting to delete it.
 				if ( members_role_exists( $role ) ) {

--- a/admin/class-roles.php
+++ b/admin/class-roles.php
@@ -98,7 +98,7 @@ final class Members_Admin_Roles {
 				check_admin_referer( 'bulk-roles' );
 
 				// Loop through each of the selected roles.
-				$roles = array_map( 'members_sanitize_role', $_POST['roles'] );
+				$roles = array_map( 'members_sanitize_role', wp_unslash( $_POST['roles'] ) );
 				foreach ( $roles as $role ) {
 
 					$role = members_sanitize_role( $role );

--- a/admin/class-roles.php
+++ b/admin/class-roles.php
@@ -98,7 +98,8 @@ final class Members_Admin_Roles {
 				check_admin_referer( 'bulk-roles' );
 
 				// Loop through each of the selected roles.
-				foreach ( $_POST['roles'] as $role ) {
+				$roles = array_map( 'members_sanitize_role', $_POST['roles'] );
+				foreach ( $roles as $role ) {
 
 					$role = members_sanitize_role( $role );
 
@@ -126,7 +127,7 @@ final class Members_Admin_Roles {
 				if ( members_role_exists( $role ) ) {
 
 					// Add role deleted message.
-					add_settings_error( 'members_roles', 'role_deleted', sprintf( esc_html__( '%s role deleted.', 'members' ), members_get_role_name( $role ) ), 'updated' );
+					add_settings_error( 'members_roles', 'role_deleted', sprintf( esc_html__( '%s role deleted.', 'members' ), esc_html( members_get_role_name( $role ) ) ), 'updated' );
 
 					// Delete the role.
 					members_delete_role( $role );
@@ -288,10 +289,10 @@ final class Members_Admin_Roles {
 		</p>
 
 		<ul>
-			<li><?php _e( '<strong>Edit</strong> takes you to the editing screen for that role. You can also reach that screen by clicking on the role name.', 'members' ); ?></li>
-			<li><?php _e( '<strong>Delete</strong> removes your role from this list and permanently deletes it.', 'members' ); ?></li>
-			<li><?php _e( '<strong>Clone</strong> copies the role and takes you to the new role screen to further edit it.', 'members' ); ?></li>
-			<li><?php _e( '<strong>Users</strong> takes you to the users screen and lists the users that have that role.', 'members' ); ?></li>
+			<li><?php echo wp_kses_post( __( '<strong>Edit</strong> takes you to the editing screen for that role. You can also reach that screen by clicking on the role name.', 'members' ) ); ?></li>
+			<li><?php  echo wp_kses_post( __( '<strong>Delete</strong> removes your role from this list and permanently deletes it.', 'members' ) ); ?></li>
+			<li><?php  echo wp_kses_post( __( '<strong>Clone</strong> copies the role and takes you to the new role screen to further edit it.', 'members' ) ); ?></li>
+			<li><?php  echo wp_kses_post( __( '<strong>Users</strong> takes you to the users screen and lists the users that have that role.', 'members' ) ); ?></li>
 		</ul>
 	<?php }
 

--- a/admin/class-roles.php
+++ b/admin/class-roles.php
@@ -82,7 +82,7 @@ final class Members_Admin_Roles {
 	public function load() {
 
 		// Get the current action if sent as request.
-		$action = isset( $_REQUEST['action'] ) ? sanitize_key( $_REQUEST['action'] ) : false;
+		$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : false;
 
 		// Get the current action if posted.
 		if ( ( isset( $_POST['action'] ) && 'delete' == $_POST['action'] ) || ( isset( $_POST['action2'] ) && 'delete' == $_POST['action2'] ) )

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -359,7 +359,7 @@ final class Members_Settings_Page {
 	public function settings_page() { ?>
 
 		<div class="wrap">
-			<h1><?php _e( 'Members Settings', 'members' ); ?></h1>
+			<h1><?php esc_html_e( 'Members Settings', 'members' ); ?></h1>
 
 			<form method="post" action="options.php">
 				<?php settings_fields( 'members_settings' ); ?>

--- a/admin/class-user-edit.php
+++ b/admin/class-user-edit.php
@@ -138,7 +138,7 @@ final class Members_Admin_User_Edit {
 			$old_roles = (array) $user->roles;
 
 			// Sanitize the posted roles.
-			$new_roles = array_map( 'members_sanitize_role', $_POST['members_user_roles'] );
+			$new_roles = array_map( 'members_sanitize_role', wp_unslash( $_POST['members_user_roles'] ) );
 
 			// Loop through the posted roles.
 			foreach ( $new_roles as $new_role ) {

--- a/admin/functions-help.php
+++ b/admin/functions-help.php
@@ -27,8 +27,8 @@ function members_get_help_sidebar_text() {
 	return sprintf(
 		'<p><strong>%s</strong></p><ul>%s%s</ul>',
 		esc_html__( 'For more information:', 'members' ),
-		wp_kses( $docs_link ),
-		wp_kses( $help_link )
+		wp_kses_post( $docs_link ),
+		wp_kses_post( $help_link )
 	);
 }
 

--- a/admin/functions-help.php
+++ b/admin/functions-help.php
@@ -27,8 +27,8 @@ function members_get_help_sidebar_text() {
 	return sprintf(
 		'<p><strong>%s</strong></p><ul>%s%s</ul>',
 		esc_html__( 'For more information:', 'members' ),
-		$docs_link,
-		$help_link
+		wp_kses( $docs_link ),
+		wp_kses( $help_link )
 	);
 }
 
@@ -142,8 +142,8 @@ function members_edit_role_help_edit_caps_cb() { ?>
 	</p>
 
 	<ul>
-		<li><?php _e( '<strong>Grant</strong> allows you to grant the role a capability.', 'members' ); ?></li>
-		<li><?php _e( '<strong>Deny</strong> allows you to explicitly deny the role a capability.', 'members' ); ?></li>
+		<li><?php echo wp_kses_post( __( '<strong>Grant</strong> allows you to grant the role a capability.', 'members' ) ); ?></li>
+		<li><?php echo wp_kses_post( __( '<strong>Deny</strong> allows you to explicitly deny the role a capability.', 'members' ) ); ?></li>
 		<li><?php esc_html_e( 'You may also opt to neither grant nor deny the role a capability.', 'members' ); ?></li>
 	</ul>
 <?php }

--- a/inc/class-widget-login.php
+++ b/inc/class-widget-login.php
@@ -118,7 +118,7 @@ class Members_Widget_Login extends WP_Widget {
 
 		// If a title was input by the user, display it.
 		if ( $instance['title'] )
-			echo $sidebar['before_title'] . apply_filters( 'widget_title',  $instance['title'], $instance, $this->id_base ) . $sidebar['after_title'];
+			echo $sidebar['before_title'] . esc_html( apply_filters( 'widget_title',  $instance['title'], $instance, $this->id_base ) ) . $sidebar['after_title'];
 
 		// If the current user is logged in.
 		if ( is_user_logged_in() ) {
@@ -129,7 +129,7 @@ class Members_Widget_Login extends WP_Widget {
 
 			// Show logged in text if any is written.
 			if ( $logged_in_text )
-				echo do_shortcode( shortcode_unautop( wpautop( $logged_in_text ) ) );
+				echo wp_kses( do_shortcode( shortcode_unautop( wpautop( $logged_in_text ) ) ) );
 		}
 
 		// If the current user is not logged in.
@@ -141,7 +141,7 @@ class Members_Widget_Login extends WP_Widget {
 
 			// Show logged out text if any is written.
 			if ( $logged_out_text )
-				echo do_shortcode( shortcode_unautop( wpautop( $logged_out_text ) ) );
+				echo wp_kses( do_shortcode( shortcode_unautop( wpautop( $logged_out_text ) ) ) );
 
 			// Output the login form.
 			echo '<div class="members-login-form">' . wp_login_form( $args ) . '</div>';
@@ -255,13 +255,13 @@ class Members_Widget_Login extends WP_Widget {
 		<p>
 			<label>
 				<input class="checkbox" type="checkbox" <?php checked( $instance['remember'] ); ?> name="<?php echo $this->get_field_name( 'remember' ); ?>" />
-				<?php _e( '"Remember me" checkbox?', 'members' ); ?>
+				<?php esc_html_e( '"Remember me" checkbox?', 'members' ); ?>
 			</label>
 		</p>
 		<p>
 			<label>
 				<input class="checkbox" type="checkbox" <?php checked( $instance['value_remember'] ); ?> name="<?php echo $this->get_field_name( 'value_remember' ); ?>" />
-				<?php _e( 'Check "remember me"?', 'members' ); ?>
+				<?php edc_html_e( 'Check "remember me"?', 'members' ); ?>
 			</label>
 		</p>
 		<p>
@@ -271,12 +271,12 @@ class Members_Widget_Login extends WP_Widget {
 			</label>
 		</p>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'logged_out_text' ); ?>"><?php _e( 'Logged out text:', 'members' ); ?></label>
+			<label for="<?php echo $this->get_field_id( 'logged_out_text' ); ?>"><?php esc_html_e( 'Logged out text:', 'members' ); ?></label>
 			<textarea class="widefat" rows="4" cols="20" id="<?php echo $this->get_field_id( 'logged_out_text' ); ?>" name="<?php echo $this->get_field_name( 'logged_out_text' ); ?>" style="width:100%;"><?php echo esc_textarea( $instance['logged_out_text'] ); ?></textarea>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'logged_in_text' ); ?>"><?php _e( 'Logged in text:', 'members' ); ?></label>
+			<label for="<?php echo $this->get_field_id( 'logged_in_text' ); ?>"><?php esc_html_e( 'Logged in text:', 'members' ); ?></label>
 			<textarea class="widefat" rows="4" cols="20" id="<?php echo $this->get_field_id( 'logged_in_text' ); ?>" name="<?php echo $this->get_field_name( 'logged_in_text' ); ?>" style="width:100%;"><?php echo esc_textarea( $instance['logged_in_text'] ); ?></textarea>
 		</p>
 

--- a/inc/class-widget-login.php
+++ b/inc/class-widget-login.php
@@ -129,7 +129,7 @@ class Members_Widget_Login extends WP_Widget {
 
 			// Show logged in text if any is written.
 			if ( $logged_in_text )
-				echo wp_kses( do_shortcode( shortcode_unautop( wpautop( $logged_in_text ) ) ) );
+				echo wp_kses_data( do_shortcode( shortcode_unautop( wpautop( $logged_in_text ) ) ) );
 		}
 
 		// If the current user is not logged in.
@@ -141,7 +141,7 @@ class Members_Widget_Login extends WP_Widget {
 
 			// Show logged out text if any is written.
 			if ( $logged_out_text )
-				echo wp_kses( do_shortcode( shortcode_unautop( wpautop( $logged_out_text ) ) ) );
+				echo wp_kses_data( do_shortcode( shortcode_unautop( wpautop( $logged_out_text ) ) ) );
 
 			// Output the login form.
 			echo '<div class="members-login-form">' . wp_login_form( $args ) . '</div>';

--- a/inc/class-widget-users.php
+++ b/inc/class-widget-users.php
@@ -100,7 +100,7 @@ class Members_Widget_Users extends WP_Widget {
 
 		// If a title was input by the user, display it.
 		if ( $instance['title'] )
-			echo $sidebar['before_title'] . apply_filters( 'widget_title',  $instance['title'], $instance, $this->id_base ) . $sidebar['after_title'];
+			echo $sidebar['before_title'] . esc_html( apply_filters( 'widget_title',  $instance['title'], $instance, $this->id_base ) ) . $sidebar['after_title'];
 
 		// Get users.
 		$users = get_users( $args );

--- a/inc/template.php
+++ b/inc/template.php
@@ -153,5 +153,5 @@ function members_list_users( $args = array() ) {
 	if ( empty( $args['echo'] ) )
 		return $output;
 
-	echo $output;
+	echo wp_kses_post( $output );
 }


### PR DESCRIPTION
I've made some minor changes to escaping and sanitization for use on a client site. At the moment, they're defensive coding rather than to protect against any flaws. 

The changes I've made are:
* unslash and sanitize  user (GET, POST, REQUEST) data as read 
* add a few instances of escaping: mainly to stop trusting translations 