### PR TITLE
Translate role labels in the new user and edit user screens

### DIFF
--- a/admin/class-user-edit.php
+++ b/admin/class-user-edit.php
@@ -105,7 +105,7 @@ final class User_Edit {
 							<li>
 								<label>
 									<input type="checkbox" name="members_user_roles[]" value="<?php echo esc_attr( $role->name ); ?>" <?php checked( in_array( $role->name, $user_roles ) ); ?> />
-									<?php echo esc_html( $role->label ); ?>
+									<?php echo esc_html( translate_user_role( $role->label ) ); ?>
 								</label>
 							</li>
 							<?php endif; ?>

--- a/admin/class-user-new.php
+++ b/admin/class-user-new.php
@@ -114,7 +114,7 @@ final class User_New {
 							<li>
 								<label>
 									<input type="checkbox" name="members_user_roles[]" value="<?php echo esc_attr( $role->name ); ?>" <?php checked( in_array( $role->name, $new_user_roles ) ); ?> />
-									<?php echo esc_html( $role->label ); ?>
+									<?php echo esc_html( translate_user_role( $role->label ) ); ?>
 								</label>
 							</li>
 							<?php endif; ?>


### PR DESCRIPTION
Role labels are not translated in the new user screen and edit user screen.

This pull request solves the issue by wrapping labels with translate_user_role calls.