### PR TITLE
Check if post_id actually exists

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -92,7 +92,12 @@ function members_can_user_view_post( $user_id, $post_id = '' ) {
 	// Set to `FALSE` to avoid hierarchical checking.
 	if ( apply_filters( 'members_check_parent_post_permission', $check_parent, $post_id, $user_id ) ) {
 
-		$parent_id = get_post( $post_id )->post_parent;
+		$parent_id = 0;
+        	$post_id = get_post($post_id);
+
+		if (is_object($post_id)) {
+		    $parent_id = $post_id->post_parent;
+		}
 
 		// If the post has a parent, check if the user has permission to view it.
 		if ( 0 < $parent_id )


### PR DESCRIPTION
Now it breaks because if the plugin can't find a post_id for whatever reason it gives a fatal error. This happens when using relevanssi for example.

This simple check fixes it. 