### PR TITLE
Invalid fallback icon

### DIFF
--- a/admin/class-addon.php
+++ b/admin/class-addon.php
@@ -168,6 +168,6 @@ final class Addon {
 		$this->name = sanitize_key( $name );
 
 		if ( ! $this->icon_url )
-			$this->icon_url = members_plugin()->dir_uri . 'img/addon.png';
+			$this->icon_url = members_plugin()->uri . 'img/icon-addon.png';
 	}
 }


### PR DESCRIPTION
The fallback path is incorrect - the property of the plugin path as well as the fallback icon.